### PR TITLE
Add service only if there's at least one handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -272,10 +272,12 @@ class Mali extends Emitter {
       const composed = {}
       const methods = this.methods[sn]
       const handlers = this.handlers[sn]
-      _.forOwn(handlers, (v, k) => {
-        composed[k] = this.callback(methods[k], v)
-      })
-      server[method](s, composed)
+      if (handlers) {
+        _.forOwn(handlers, (v, k) => {
+          composed[k] = this.callback(methods[k], v)
+        })
+        server[method](s, composed)
+      }
     })
 
     server.bind(port, creds)


### PR DESCRIPTION
Proto definition may contain services that are not intended
to be included in the server.